### PR TITLE
fix: Aggiornate dipendenze go per includere pacchetti mancanti

### DIFF
--- a/cmd/edge-hub/main.go
+++ b/cmd/edge-hub/main.go
@@ -1,12 +1,11 @@
 package main
 
 import (
+	"SensorContinuum/internal/edge-hub"
 	"SensorContinuum/internal/edge-hub/comunication"
+	"SensorContinuum/pkg/logger"
 	"SensorContinuum/pkg/structure"
 	"os"
-
-	"SensorContinuum/internal/edge-hub"
-	"SensorContinuum/pkg/logger"
 )
 
 // getContext ritorna il contesto del logger con le informazioni specifiche dell'hub

--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,12 @@ module SensorContinuum
 
 go 1.24.5
 
-require github.com/eclipse/paho.mqtt.golang v1.5.0
+require (
+	github.com/eclipse/paho.mqtt.golang v1.5.0
+	github.com/google/uuid v1.6.0
+)
 
 require (
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	golang.org/x/net v0.27.0 // indirect
 	golang.org/x/sync v0.7.0 // indirect


### PR DESCRIPTION
Questa PR svolge 2 ruoli:
**IL PRIMO** è verificare che non ci siano problemi con GitHub nell'avanzare delle richieste di push ( è più una garanzia per me sviluppatore) 
**IL SECONDO** è di risolvere problemi legati alle dipendenze presenti in go.mod e go.sum